### PR TITLE
商品一覧ページの作成と、各種リンク先設定の修正

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,11 +15,11 @@
             <li>
               <span>
                 <% if spree_current_user %>
-                  <%= link_to "Log out", potepan_logout_path %>
+                  <%= link_to "ログアウト", potepan_logout_path %>
                 <% else %>
-                  <%= link_to "Log in", "", href: "#login", data: { toggle: "modal" } %>
+                  <%= link_to "ログイン", "", href: "#login", data: { toggle: "modal" } %>
                   <small>or</small>
-                  <%= link_to "Create an account", "", href: "#signup", data: { toggle: "modal" } %>
+                  <%= link_to "新規アカウント作成", "", href: "#signup", data: { toggle: "modal" } %>
                 <% end %>
               </span>
             </li>
@@ -37,7 +37,9 @@
               </ul>
             </li>
             <li class="dropdown">
-              <a href="cart-page.html" class="dropdown-toggle" data-toggle="dropdown disabled"><i class="fa fa-shopping-cart"></i></a>
+              <%= link_to(potepan_cart_path, class: "dropdown-toggle") do %>
+                <i class="fa fa-shopping-cart"></i>
+              <% end %>
             </li>
           </ul>
         </div>
@@ -55,14 +57,14 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" href="javascript:void(0)"><%= image_tag("logo.png") %></a>
+        <%= link_to image_tag("logo.png"), potepan_root_path, class: "navbar-brand" %>
       </div>
       <!-- Collect the nav links, forms, and other content for toggling -->
       <div class="collapse navbar-collapse navbar-ex1-collapse">
         <ul class="nav navbar-nav navbar-right">
-          <li class="active"><a href="javascript:void(0)">Home</a></li>
+          <li class="active"><%= link_to "HOME", potepan_root_path %></li>
           <li class="dropdown megaDropMenu">
-            <a href="javascript:void(0)" class="dropdown-toggle" data-toggle="dropdown" data-hover="dropdown" data-delay="300" data-close-others="true" aria-expanded="false">Shop</a>
+            <%= link_to "SHOP", potepan_categories_path %>
           </li>
         </ul>
       </div>

--- a/app/views/potepan/categories/_filter_by_color.html.erb
+++ b/app/views/potepan/categories/_filter_by_color.html.erb
@@ -4,8 +4,14 @@
     <ul class="list-unstyled">
       <% option_types.colors.each do |color| %>
         <li>
-          <%= link_to potepan_category_path(params[:id], color: color.name) do %>
-            <%= color.presentation %><span><%= "(#{count_number_of_products(color.name)})" %></span>
+          <% if params[:id] %>
+            <%= link_to potepan_category_path(params[:id], color: color.name) do %>
+              <%= color.presentation %><span><%= "(#{count_number_of_show_products(color.name)})" %></span>
+            <% end %>
+          <% else %>
+            <%= link_to potepan_categories_path(color: color.name) do %>
+              <%= color.presentation %><span><%= "(#{count_number_of_index_products(color.name)})" %></span>
+            <% end %>
           <% end %>
         </li>
       <% end %>

--- a/app/views/potepan/categories/_filter_by_size.html.erb
+++ b/app/views/potepan/categories/_filter_by_size.html.erb
@@ -4,9 +4,15 @@
     <ul class="list-unstyled clearfix">
       <% option_types.sizes.each do |size| %>
         <li>
-          <%= link_to potepan_category_path(params[:id], size: size.name) do %>
-            <%= size.presentation %><span><%= "(#{count_number_of_products(size.name)})" %></span>
-          <% end %>
+          <% if params[:id] %>
+            <%= link_to potepan_category_path(params[:id], size: size.name) do %>
+              <%= size.presentation %><span><%= "(#{count_number_of_show_products(size.name)})" %></span>
+            <% end %>
+          <% else %>
+            <%= link_to potepan_categories_path(size: size.name) do %>
+              <%= size.presentation %><span><%= "(#{count_number_of_index_products(size.name)})" %></span>
+            <% end %>
+          <% end %>  
         </li>
       <% end %>
     </ul>

--- a/app/views/potepan/categories/index.html.erb
+++ b/app/views/potepan/categories/index.html.erb
@@ -1,0 +1,24 @@
+<div class="main-wrapper">
+  <!-- MAIN CONTENT SECTION -->
+  <section class="mainContent clearfix productsContent">
+    <div class="container">
+      <div class="row">
+        <div class="col-md-3 col-sm-4 col-xs-12 sideBar">
+          <%= render "filter_by_category", taxonomies: @taxonomies %>
+          <%= render "filter_by_color", option_types: @option_types %>
+          <%= render "filter_by_size", option_types: @option_types %>
+        </div>
+        <div class="col-md-9 col-sm-8 col-xs-12">
+          <div class="row filterArea">
+            <%= render "filter_by_sort" %>
+            <%= render "filter_by_grid_or_list" %>
+          </div>
+          <%= render "main_panel", products: @products %>
+        </div>
+      </div>
+    </div>
+  </section>
+  <%= render "potepan/shared/partners" %>
+</div>
+<%= render "potepan/shared/login_modal" %>
+<%= render "potepan/shared/signup_modal" %>

--- a/app/views/potepan/products/show.html.erb
+++ b/app/views/potepan/products/show.html.erb
@@ -38,8 +38,8 @@
             <div class="media-body">
               <ul class="list-inline">
                 <li>
-                  <%= link_to potepan_category_path(@product.taxons.first.id) do %>
-                    一覧ページへ戻る<i class="fa fa-reply" aria-hidden="true"></i>
+                  <%= link_to potepan_categories_path do %>
+                    一覧ページ<i class="fa fa-reply" aria-hidden="true"></i>
                   <% end %>
                 </li>
               </ul>

--- a/app/views/potepan/shared/_light_section.html.erb
+++ b/app/views/potepan/shared/_light_section.html.erb
@@ -1,21 +1,10 @@
 <section class="lightSection clearfix pageHeader">
   <div class="container">
     <div class="row">
-      <div class="col-xs-6">
+      <div class="col-xs-12">
         <div class="page-title">
           <h2><%= element.name %></h2>
         </div>
-      </div>
-      <div class="col-xs-6">
-        <ol class="breadcrumb pull-right">
-          <li>
-            <%= link_to "Home", potepan_root_path %>
-          </li>
-          <li>
-            <a href="#">shop</a>
-          </li>
-          <li class="active"><%= element.name %></li>
-        </ol>
       </div>
     </div>
   </div>

--- a/app/views/potepan/shared/_login_modal.html.erb
+++ b/app/views/potepan/shared/_login_modal.html.erb
@@ -3,25 +3,25 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h3 class="modal-title">log in</h3>
+        <h3 class="modal-title">ログイン</h3>
       </div>
       <div class="modal-body">
         <%= form_for Spree::User.new, as: :spree_user, url: potepan_create_new_session_path do |f| %>
           <div class="form-group">
-            <%= f.label :email, "Enter Email" %>
+            <%= f.label :email, "メールアドレス" %>
             <%= f.email_field :email, class: "form-control" %>
           </div>
           <div class="form-group">
-            <%= f.label :password, "Password" %>
+            <%= f.label :password, "パスワード" %>
             <%= f.password_field :password, class: "form-control", tabindex: 2 %>
           </div>
           <div class="checkbox">
             <label>
-              <%= f.check_box :remember_me, tabindex: 3 %> Remember Me
+              <%= f.check_box :remember_me, tabindex: 3 %> パスワードを記憶する
             </label>
           </div>
-          <%= f.submit "log in", class: "btn btn-primary btn-block" %>
-          <button type="button" class="btn btn-link btn-block">Forgot Password?</button>
+          <%= f.submit "ログイン", class: "btn btn-primary btn-block" %>
+          <button type="button" class="btn btn-link btn-block">パスワードを忘れた方はこちら</button>
         <% end %>
       </div>
     </div>

--- a/app/views/potepan/shared/_signup_modal.html.erb
+++ b/app/views/potepan/shared/_signup_modal.html.erb
@@ -3,23 +3,23 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h3 class="modal-title">Create an account</h3>
+        <h3 class="modal-title">アカウント作成</h3>
       </div>
       <div class="modal-body">
         <%= form_for Spree::User.new, as: :spree_user, url: potepan_registration_path do |f| %>
           <div class="form-group">
-            <%= f.label :email, "Enter Email" %>
+            <%= f.label :email, "メールアドレス" %>
             <%= f.email_field :email, class: "form-control" %>
           </div>
           <div class="form-group">
-            <%= f.label :password, "Password" %>
+            <%= f.label :password, "パスワード" %>
             <%= f.password_field :password, class: "form-control" %>
           </div>
           <div class="form-group">
-            <%= f.label :password_confirmation, "Confirm Password" %>
+            <%= f.label :password_confirmation, "パスワード確認" %>
             <%= f.password_field :password_confirmation, class: "form-control" %>
           </div>
-          <%= f.submit "Sign up", class: "btn btn-primary btn-block" %>
+          <%= f.submit "新規作成", class: "btn btn-primary btn-block" %>
         <% end %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
         get 'search'
       end
     end
-    resources :categories, only: [:show]
+    resources :categories, only: [:index, :show]
     resources :orders, only: [:show]
     get 'cart', to: 'orders#edit'
     post 'add_cart', to: 'orders#add_cart'

--- a/spec/features/categories_spec.rb
+++ b/spec/features/categories_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Categories", type: :feature do
 
   # homeページにアクセスできることを確認
   scenario "User accesses a home page from a categories page" do
-    click_link "Home", href: potepan_root_path
+    click_link "HOME", href: potepan_root_path
 
     expect(page).to have_current_path potepan_root_path
   end

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -8,77 +8,77 @@ RSpec.feature "login", type: :feature do
   scenario "Registerate new user then login" do
     visit potepan_root_path
 
-    # Create an accountをクリック
-    click_on "Create an account"
+    # アカウント作成をクリック
+    click_on "アカウント作成"
 
     # パスワードミス
     within("div#signup") do
-      fill_in "Enter Email", with: "user@example.com"
+      fill_in "spree_user[email]", with: "user@example.com"
       fill_in "spree_user[password]", with: "i_am_user"
       fill_in "spree_user[password_confirmation]", with: "i_am_not_user"
-      click_on "Sign up"
+      click_on "新規作成"
     end
     expect(page).to have_content "Invalid email or password."
     expect(current_url).to eq potepan_root_url
 
-    # Create an accountをクリック
-    click_on "Create an account"
+    # アカウント作成をクリック
+    click_on "アカウント作成"
 
     # パスワードOK
     within("div#signup") do
-      fill_in "Enter Email", with: "user@example.com"
+      fill_in "spree_user[email]", with: "user@example.com"
       fill_in "spree_user[password]", with: "i_am_user"
       fill_in "spree_user[password_confirmation]", with: "i_am_user"
-      click_on "Sign up"
+      click_on "新規作成"
     end
     expect(page).to have_content "Welcome! You have signed up successfully."
     expect(current_url).to eq potepan_root_url
-    expect(page).to have_content "Log out"
+    expect(page).to have_content "ログアウト"
   end
 
   scenario "login and logout" do
     visit potepan_root_path
 
-    # Create an accountをクリック
-    click_on "Log in"
+    # ログインをクリック
+    click_on "ログイン", match: :first
 
     # メールアドレスミス
     within("div#login") do
-      fill_in "Enter Email", with: "not_test@example.com"
+      fill_in "spree_user[email]", with: "not_test@example.com"
       fill_in "spree_user[password]", with: "testuser"
-      click_on "log in"
+      click_on "ログイン"
     end
     expect(page).to have_content "Invalid email or password."
     expect(current_url).to eq potepan_root_url
 
-    # Create an accountをクリック
-    click_on "Log in"
+    # ログインをクリック
+    click_on "ログイン", match: :first
 
     # パスワードミス
     within("div#login") do
-      fill_in "Enter Email", with: "test@example.com"
+      fill_in "spree_user[email]", with: "test@example.com"
       fill_in "spree_user[password]", with: "not_testuser"
-      click_on "log in"
+      click_on "ログイン"
     end
     expect(page).to have_content "Invalid email or password."
     expect(current_url).to eq potepan_root_url
 
-    # Create an accountをクリック
-    click_on "Log in"
+    # ログインをクリック
+    click_on "ログイン", match: :first
 
     # メールアドレス&パスワードOK
     within("div#login") do
-      fill_in "Enter Email", with: "test@example.com"
+      fill_in "spree_user[email]", with: "test@example.com"
       fill_in "spree_user[password]", with: "testuser"
-      click_on "log in"
+      click_on "ログイン"
     end
     expect(page).to have_content "Logged in successfully"
     expect(current_url).to eq potepan_root_url
 
-    # Log outをクリック
-    click_on "Log out"
+    # ログアウトをクリック
+    click_on "ログアウト"
     expect(page).to have_content "Signed out successfully."
     expect(current_url).to eq potepan_root_url
-    expect(page).to have_content "Log in"
+    expect(page).to have_content "ログイン"
   end
 end

--- a/spec/features/products_spec.rb
+++ b/spec/features/products_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature "Products", type: :feature do
   scenario "User accesses show page" do
     visit potepan_product_path(product.id)
     within ".media-body" do
-      expect(page).to have_link "一覧ページへ戻る", href: potepan_category_path(product.taxons.ids.first)
+      expect(page).to have_link "一覧ページ", href: potepan_categories_path
       expect(page).to have_content product.name
       expect(page).to have_content product.display_price
       expect(page).to have_content product.description


### PR DESCRIPTION
1．商品一覧ページ（Categories#index）の作成
2．以下リンク先設定の修正
・ヘッダーのロゴ・HOMEに、トップページを設定
・ヘッダーのSHOPに、商品一覧ページを設定を設定
・ヘッダーのカートアイコンに、カートページを設定
・Product Showページ内の「一覧ページ」に、商品一覧ページを設定
3．サインアップ・ログインモーダルの日本語化