### PR TITLE
注文完了画面と、確認画面で注文個数を変更できるバグの修正

### DIFF
--- a/app/controllers/potepan/checkout_controller.rb
+++ b/app/controllers/potepan/checkout_controller.rb
@@ -57,7 +57,6 @@ class Potepan::CheckoutController < ApplicationController
 
   def set_successful_flash_notice
     flash.notice = t('spree.order_processed_successfully')
-    flash['order_completed'] = true
   end
 
   def send_to_next_state

--- a/app/views/potepan/orders/_line_item.html.erb
+++ b/app/views/potepan/orders/_line_item.html.erb
@@ -15,7 +15,11 @@
       <%= line_item.display_price %>
     </td>
     <td class="col-xs-2">
-      <%= line_item_fields.number_field :quantity, min: 0 %>
+      <% if params[:state] == "confirm" %>
+        <%= line_item.quantity %>
+      <% else %>
+        <%= line_item_fields.number_field :quantity, min: 0 %>
+      <% end %>
     </td>
     <td class="col-xs-2">
       <%= line_item.display_total %>

--- a/app/views/potepan/orders/_order_form.html.erb
+++ b/app/views/potepan/orders/_order_form.html.erb
@@ -29,6 +29,7 @@
           <%= order.display_item_total %>
         </span>
       </li>
+      <% if params[:state] == "confirm" %>
       <li>消費税
         <span>
           <%= order.display_additional_tax_total %>
@@ -44,6 +45,7 @@
           <%= order.display_total %>
         </span>
       </li>
+      <% end %>
     </ul>
   </div>
 </div>

--- a/app/views/potepan/orders/show.html.erb
+++ b/app/views/potepan/orders/show.html.erb
@@ -5,20 +5,23 @@
       <div class="row">
         <div class="col-xs-12">
           <div class="thanksContent">
-            <h2>Thank You !! <small>ご注文ありがとうございます。</small></h2>
-            <h3>Shipping Details</h3>
+            <h2>Thank You !! <small>ご注文ありがとうございます。ご入力いただいたメールアドレスに、ご注文の詳細を送信いたしました。</small></h2>
+            <h3>ご注文内容</h3>
             <div class="thanksInner">
               <div class="row">
                 <div class="col-sm-6 col-xs-12 tableBlcok">
                   <address>
-                    <span>Shipping address:</span> <a href="#"><%= @order.email %></a> <br>
-                    <span>Email:</span> <a href="#"><%= @order.email %></a> <br>
-                    <span>Phone:</span> <%= @order.ship_address.phone %>
+                    <span>ご注文の商品：</span><br>
+                    <% @order.line_items.includes(variant: [:product]).each do |line_item| %>
+                      ・<%= line_item.name %>（<%= line_item.quantity %>コ）<br>
+                    <% end %><br>
+                    <span>メールアドレス：</span> <%= @order.email %> <br>
+                    <span>電話番号：</span> <%= @order.ship_address.phone %>
                   </address>
                 </div>
                 <div class="col-sm-6 col-xs-12">
                   <div class="well">
-                    <h2><small>Order ID</small><%= @order.number %></h2>
+                    <h2><small>注文番号</small><%= @order.number %></h2>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
以下作業を実行
・注文完了画面に注文内容の詳細を追加し、不要な記述を削除。
・注文完了後に表示される不要な記述を削除。
・消費税と送料が計算されるのはCheckoutControllerが動いてからなので、確認画面にのみ表示させるように変更。
・注文内容確認時に商品個数を変更できるバグを修正。