### PR TITLE
注文確認画面から削除ボタンを取り除き、カートlight_sectionのlinkを修正

### DIFF
--- a/app/views/potepan/orders/_light_section.html.erb
+++ b/app/views/potepan/orders/_light_section.html.erb
@@ -7,7 +7,7 @@
             <h2>cart</h2>
             <ol class="breadcrumb">
               <li>
-                <a href="index.html">Home</a>
+                <%= link_to "Home", potepan_root_path %>
               </li>
               <li class="active">cart</li>
             </ol>

--- a/app/views/potepan/orders/_line_item.html.erb
+++ b/app/views/potepan/orders/_line_item.html.erb
@@ -1,8 +1,10 @@
 <%= order_form.fields_for :line_items, line_item do |line_item_fields| %>
   <tr>
     <td class="col-xs-2">
-      <%= link_to potepan_line_item_path(line_item), class: "close", method: :delete  do %>
-        <span aria-hidden="true">&times;</span>
+      <% unless params[:state] == "confirm" %>
+        <%= link_to potepan_line_item_path(line_item), class: "close", method: :delete  do %>
+          <span aria-hidden="true">&times;</span>
+        <% end %>
       <% end %>
       <span class="cartImage">
         <%= image_tag(line_item.variant.display_image.attachment(:small)) %>


### PR DESCRIPTION
以下作業を実行
・注文確認画面から削除ボタンを除去
・カートlight_sectionの「HOME」のlinkが正常に設定されていなかったため、ルートパスを設定