### PR TITLE
購入履歴の文言が、カートページのものになっていたため修正

### DIFF
--- a/app/views/potepan/orders/history.html.erb
+++ b/app/views/potepan/orders/history.html.erb
@@ -4,7 +4,7 @@
     <div class="container">
       <div class="row">
         <% if @orders.empty? %>
-          <p>カートは空です。</p>
+          <p>購入履歴はございません。</p>
         <% else %>
           <% @orders.each do |order| %>
             <%= render 'order_history', order: order %>


### PR DESCRIPTION
購入履歴の文言が「カートは空です。」とカートページのものになっていたため、「購入履歴はございません。」に修正。