### PR TITLE
パスワード再生成の文言を削除

### DIFF
--- a/app/views/potepan/shared/_login_modal.html.erb
+++ b/app/views/potepan/shared/_login_modal.html.erb
@@ -21,7 +21,6 @@
             </label>
           </div>
           <%= f.submit "ログイン", class: "btn btn-primary btn-block" %>
-          <button type="button" class="btn btn-link btn-block">パスワードを忘れた方はこちら</button>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
spree_auth_deviseにてパスワード再設定のフローが複雑になっており、再設定が困難であるため一時リンクを削除。